### PR TITLE
Clear rejected responses from pendingCalls

### DIFF
--- a/src/plinko.js
+++ b/src/plinko.js
@@ -174,14 +174,14 @@ const Plinko = {
     }
 
     const pendingCall = this.pendingCalls[callId];
+    delete this.pendingCalls[callId];
+
     if (rejected) {
       pendingCall.reject(returnValue);
       return;
     }
 
     pendingCall.resolve(returnValue);
-
-    delete this.pendingCalls[callId];
   }
 };
 


### PR DESCRIPTION
Rejected responses were not being cleared from pendingCalls and were
becoming a memory leak since nothing was ever going to clean them up.

Resolves #5