### PR TITLE
Add support for disposing of message event listeners

### DIFF
--- a/src/driver/extension-driver.js
+++ b/src/driver/extension-driver.js
@@ -24,7 +24,8 @@ const ExtensionDriver = {
 
     Object.assign(driver, {
       browser: chrome || browser,
-      scriptType
+      scriptType,
+      onMessageCallback: null,
     });
 
     return driver;
@@ -52,7 +53,7 @@ const ExtensionDriver = {
   },
 
   setupListener(receiveMessage) {
-    this.browser.runtime.onMessage.addListener((message, sender) => {
+    this.onMessageCallback = (message, sender) => {
       if (this.scriptType !== message.targetScriptType) {
         return;
       }
@@ -63,7 +64,9 @@ const ExtensionDriver = {
       }
 
       receiveMessage(source, message.plinkoMessage);
-    });
+    };
+
+    this.browser.runtime.onMessage.addListener(this.onMessageCallback);
   },
 
   sendMessage(target, message) {
@@ -73,7 +76,13 @@ const ExtensionDriver = {
     }
 
     sendTabMessage.call(this, target, message);
-  }
+  },
+
+  dispose() {
+    if (this.onMessageCallback) {
+      this.browser.runtime.onMessage.removeListener(this.onMessageCallback);
+    }
+  },
 };
 
 export default ExtensionDriver;

--- a/src/driver/window-driver.js
+++ b/src/driver/window-driver.js
@@ -5,7 +5,8 @@ const WindowDriver = {
     thisWindow = thisWindow || window;
     Object.assign(driver, {
       window: thisWindow,
-      expectedOrigin: expectedOrigin || thisWindow.location.origin
+      expectedOrigin: expectedOrigin || thisWindow.location.origin,
+      onMessageCallback: null,
     });
 
     return driver;
@@ -16,18 +17,26 @@ const WindowDriver = {
   },
 
   setupListener(receiveMessage) {
-    this.window.addEventListener('message', event => {
+    this.onMessageCallback = event => {
       if (this.expectedOrigin !== '*' && this.expectedOrigin !== event.origin) {
         return;
       }
 
       receiveMessage(event.source, event.data);
-    });
+    };
+
+    this.window.addEventListener('message', this.onMessageCallback);
   },
 
   sendMessage(target, message) {
     target.postMessage(message, this.expectedOrigin);
-  }
+  },
+
+  dispose() {
+    if (this.onMessageCallback) {
+      this.window.removeEventListener('message', this.onMessageCallback);
+    }
+  },
 };
 
 export default WindowDriver;

--- a/src/plinko.js
+++ b/src/plinko.js
@@ -109,6 +109,10 @@ const Plinko = {
     };
   },
 
+  dispose() {
+    this.driver.dispose();
+  },
+
   closeRequest(request, rejected, returnValue) {
     const {source: target, message: {callId}} = request;
 


### PR DESCRIPTION
Sometimes the plinko instance needs to be removed, which means the event
listeners need to be disposed.  The `plinko.dispose()` method will do
the necessary cleanup of global state so the plinko instance is no
longer listening for incoming messages.